### PR TITLE
Add link to packaged version for openSUSE/SLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ done
 * [Linux]
     * [Arch Linux AUR](https://aur.archlinux.org/packages/minikube/)
     * [Fedora/CentOS/Red Hat COPR](https://copr.fedorainfracloud.org/coprs/antonpatsev/minikube-rpm/)
+    * [openSUSE/SUSE Linux Enterprise](https://build.opensuse.org/package/show/Virtualization:containers/minikube)
 * [Windows] [Chocolatey](https://chocolatey.org/packages/Minikube)
 
 ### Minikube Version Management


### PR DESCRIPTION
This adds a link to the packaged version of minikube available on OBS for openSUSE and SUSE Enterprise.

Patch for Issue #2899